### PR TITLE
Fix sample prompt argument in generated training script

### DIFF
--- a/app.py
+++ b/app.py
@@ -406,7 +406,8 @@ def gen_sh(
     ############# Sample args ########################
     sample = ""
     if len(sample_prompts) > 0 and sample_every_n_steps > 0:
-        sample = f"""--sample_prompts={sample_prompts_path} --sample_every_n_steps="{sample_every_n_steps}" {line_break}"""
+        # ensure the sample args appear on a new line in the generated script
+        sample = f"\n  --sample_prompts={sample_prompts_path} --sample_every_n_steps=\"{sample_every_n_steps}\" {line_break}"
 
 
     ############# Optimizer args ########################


### PR DESCRIPTION
## Summary
- ensure sample prompt arguments are added on a new line when generating the training script

## Testing
- `pip install gradio==3.48.0 python-slugify pyyaml toml --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688be8aa3eb083259b37300741a9ead4